### PR TITLE
commenting out the SWC logo from navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -10,7 +10,8 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-
+	    
+<!--
       {% comment %} Select what logo to display. {% endcomment %}
       {% if site.carpentry == "swc" %}
       <a href="{{ site.swc_site }}" class="pull-left">
@@ -29,6 +30,7 @@
         <img class="navbar-logo" src="{{ page.root }}/assets/img/cp-logo-blue.svg" alt="The Carpentries logo" />
       </a>
       {% endif %}
+-->
 
       {% comment %} Always show link to home page. {% endcomment %}
       <a class="navbar-brand" href="{{ page.root }}{% link index.md %}">Home</a>


### PR DESCRIPTION
...to avoid pointing people to the Software Carpentry website, and because our lessons for CogSci are not SWC lessons, though we're allowed to use the website template, per their open license.